### PR TITLE
jamovi - added suggested for all variable controls

### DIFF
--- a/R/jamovicorrelation.h.R
+++ b/R/jamovicorrelation.h.R
@@ -114,11 +114,15 @@ jamovicorrelationOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R
             private$..x <- jmvcore::OptionVariable$new(
                 "x",
                 x,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..y <- jmvcore::OptionVariable$new(
                 "y",
                 y,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..r <- jmvcore::OptionString$new(

--- a/R/jamovidescribe.h.R
+++ b/R/jamovidescribe.h.R
@@ -43,6 +43,8 @@ jamovidescribeOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..outcome_variable <- jmvcore::OptionVariable$new(
                 "outcome_variable",
                 outcome_variable,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..show_details <- jmvcore::OptionBool$new(

--- a/R/jamovimagnitude.h.R
+++ b/R/jamovimagnitude.h.R
@@ -70,6 +70,8 @@ jamovimagnitudeOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6C
             private$..outcome_variable <- jmvcore::OptionVariables$new(
                 "outcome_variable",
                 outcome_variable,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..mean <- jmvcore::OptionString$new(

--- a/R/jamovimdiff2x2.h.R
+++ b/R/jamovimdiff2x2.h.R
@@ -149,26 +149,38 @@ jamovimdiff2x2Options <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..outcome_variable <- jmvcore::OptionVariable$new(
                 "outcome_variable",
                 outcome_variable,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..grouping_variable_A <- jmvcore::OptionVariable$new(
                 "grouping_variable_A",
                 grouping_variable_A,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..grouping_variable_B <- jmvcore::OptionVariable$new(
                 "grouping_variable_B",
                 grouping_variable_B,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..outcome_variable_level1 <- jmvcore::OptionVariable$new(
                 "outcome_variable_level1",
                 outcome_variable_level1,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..outcome_variable_level2 <- jmvcore::OptionVariable$new(
                 "outcome_variable_level2",
                 outcome_variable_level2,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..outcome_variable_name_bs <- jmvcore::OptionString$new(
@@ -178,6 +190,9 @@ jamovimdiff2x2Options <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..grouping_variable <- jmvcore::OptionVariable$new(
                 "grouping_variable",
                 grouping_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..repeated_measures_name <- jmvcore::OptionString$new(

--- a/R/jamovimdiffindcontrast.h.R
+++ b/R/jamovimdiffindcontrast.h.R
@@ -122,31 +122,45 @@ jamovimdiffindcontrastOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) 
             private$..outcome_variable <- jmvcore::OptionVariables$new(
                 "outcome_variable",
                 outcome_variable,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..grouping_variable <- jmvcore::OptionVariable$new(
                 "grouping_variable",
                 grouping_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..means <- jmvcore::OptionVariable$new(
                 "means",
                 means,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..sds <- jmvcore::OptionVariable$new(
                 "sds",
                 sds,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..ns <- jmvcore::OptionVariable$new(
                 "ns",
                 ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..grouping_variable_levels <- jmvcore::OptionVariable$new(
                 "grouping_variable_levels",
                 grouping_variable_levels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..outcome_variable_name <- jmvcore::OptionString$new(

--- a/R/jamovimdiffpaired.h.R
+++ b/R/jamovimdiffpaired.h.R
@@ -114,11 +114,15 @@ jamovimdiffpairedOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R
             private$..reference_measure <- jmvcore::OptionVariable$new(
                 "reference_measure",
                 reference_measure,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..comparison_measure <- jmvcore::OptionVariable$new(
                 "comparison_measure",
                 comparison_measure,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..comparison_mean <- jmvcore::OptionString$new(

--- a/R/jamovimdifftwo.h.R
+++ b/R/jamovimdifftwo.h.R
@@ -111,11 +111,16 @@ jamovimdifftwoOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..outcome_variable <- jmvcore::OptionVariables$new(
                 "outcome_variable",
                 outcome_variable,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..grouping_variable <- jmvcore::OptionVariable$new(
                 "grouping_variable",
                 grouping_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..reference_level_name <- jmvcore::OptionString$new(

--- a/R/jamovimetamdiff.h.R
+++ b/R/jamovimetamdiff.h.R
@@ -108,70 +108,112 @@ jamovimetamdiffOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6C
             private$..comparison_means <- jmvcore::OptionVariable$new(
                 "comparison_means",
                 comparison_means,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..comparison_sds <- jmvcore::OptionVariable$new(
                 "comparison_sds",
                 comparison_sds,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..comparison_ns <- jmvcore::OptionVariable$new(
                 "comparison_ns",
                 comparison_ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..reference_means <- jmvcore::OptionVariable$new(
                 "reference_means",
                 reference_means,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..reference_sds <- jmvcore::OptionVariable$new(
                 "reference_sds",
                 reference_sds,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..reference_ns <- jmvcore::OptionVariable$new(
                 "reference_ns",
                 reference_ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..r <- jmvcore::OptionVariable$new(
                 "r",
                 r,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..labels <- jmvcore::OptionVariable$new(
                 "labels",
-                labels)
+                labels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..moderator <- jmvcore::OptionVariable$new(
                 "moderator",
-                moderator)
+                moderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..d <- jmvcore::OptionVariable$new(
                 "d",
                 d,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..dcomparison_ns <- jmvcore::OptionVariable$new(
                 "dcomparison_ns",
                 dcomparison_ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..dreference_ns <- jmvcore::OptionVariable$new(
                 "dreference_ns",
                 dreference_ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..dr <- jmvcore::OptionVariable$new(
                 "dr",
                 dr,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..dlabels <- jmvcore::OptionVariable$new(
                 "dlabels",
-                dlabels)
+                dlabels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..dmoderator <- jmvcore::OptionVariable$new(
                 "dmoderator",
-                dmoderator)
+                dmoderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..conf_level <- jmvcore::OptionNumber$new(
                 "conf_level",
                 conf_level,
@@ -2397,6 +2439,10 @@ jamovimetamdiff <- function(
             `if`( ! missing(dlabels), dlabels, NULL),
             `if`( ! missing(dmoderator), dmoderator, NULL))
 
+    for (v in labels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in moderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in dlabels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in dmoderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamovimetamdiffOptions$new(
         switch = switch,

--- a/R/jamovimetamean.h.R
+++ b/R/jamovimetamean.h.R
@@ -102,40 +102,70 @@ jamovimetameanOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..means <- jmvcore::OptionVariable$new(
                 "means",
                 means,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..sds <- jmvcore::OptionVariable$new(
                 "sds",
                 sds,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..ns <- jmvcore::OptionVariable$new(
                 "ns",
                 ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..labels <- jmvcore::OptionVariable$new(
                 "labels",
-                labels)
+                labels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..moderator <- jmvcore::OptionVariable$new(
                 "moderator",
-                moderator)
+                moderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..ds <- jmvcore::OptionVariable$new(
                 "ds",
                 ds,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..dns <- jmvcore::OptionVariable$new(
                 "dns",
                 dns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..dlabels <- jmvcore::OptionVariable$new(
                 "dlabels",
-                dlabels)
+                dlabels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..dmoderator <- jmvcore::OptionVariable$new(
                 "dmoderator",
-                dmoderator)
+                dmoderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..conf_level <- jmvcore::OptionNumber$new(
                 "conf_level",
                 conf_level,
@@ -2261,6 +2291,10 @@ jamovimetamean <- function(
             `if`( ! missing(dlabels), dlabels, NULL),
             `if`( ! missing(dmoderator), dmoderator, NULL))
 
+    for (v in labels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in moderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in dlabels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in dmoderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamovimetameanOptions$new(
         switch = switch,

--- a/R/jamovimetapdiff.h.R
+++ b/R/jamovimetapdiff.h.R
@@ -90,29 +90,47 @@ jamovimetapdiffOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6C
             private$..reference_cases <- jmvcore::OptionVariable$new(
                 "reference_cases",
                 reference_cases,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..reference_ns <- jmvcore::OptionVariable$new(
                 "reference_ns",
                 reference_ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..comparison_cases <- jmvcore::OptionVariable$new(
                 "comparison_cases",
                 comparison_cases,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..comparison_ns <- jmvcore::OptionVariable$new(
                 "comparison_ns",
                 comparison_ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..labels <- jmvcore::OptionVariable$new(
                 "labels",
-                labels)
+                labels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..moderator <- jmvcore::OptionVariable$new(
                 "moderator",
-                moderator)
+                moderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..effect_label <- jmvcore::OptionString$new(
                 "effect_label",
                 effect_label,
@@ -2138,6 +2156,8 @@ jamovimetapdiff <- function(
             `if`( ! missing(labels), labels, NULL),
             `if`( ! missing(moderator), moderator, NULL))
 
+    for (v in labels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in moderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamovimetapdiffOptions$new(
         reference_cases = reference_cases,

--- a/R/jamovimetaproportion.h.R
+++ b/R/jamovimetaproportion.h.R
@@ -87,19 +87,33 @@ jamovimetaproportionOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6
             private$..cases <- jmvcore::OptionVariable$new(
                 "cases",
                 cases,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..ns <- jmvcore::OptionVariable$new(
                 "ns",
                 ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..labels <- jmvcore::OptionVariable$new(
                 "labels",
-                labels)
+                labels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..moderator <- jmvcore::OptionVariable$new(
                 "moderator",
-                moderator)
+                moderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..effect_label <- jmvcore::OptionString$new(
                 "effect_label",
                 effect_label,
@@ -2071,6 +2085,8 @@ jamovimetaproportion <- function(
             `if`( ! missing(labels), labels, NULL),
             `if`( ! missing(moderator), moderator, NULL))
 
+    for (v in labels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in moderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamovimetaproportionOptions$new(
         cases = cases,

--- a/R/jamovimetar.h.R
+++ b/R/jamovimetar.h.R
@@ -87,19 +87,33 @@ jamovimetarOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class
             private$..rs <- jmvcore::OptionVariable$new(
                 "rs",
                 rs,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..ns <- jmvcore::OptionVariable$new(
                 "ns",
                 ns,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..labels <- jmvcore::OptionVariable$new(
                 "labels",
-                labels)
+                labels,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..moderator <- jmvcore::OptionVariable$new(
                 "moderator",
-                moderator)
+                moderator,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..effect_label <- jmvcore::OptionString$new(
                 "effect_label",
                 effect_label,
@@ -2096,6 +2110,8 @@ jamovimetar <- function(
             `if`( ! missing(labels), labels, NULL),
             `if`( ! missing(moderator), moderator, NULL))
 
+    for (v in labels) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in moderator) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamovimetarOptions$new(
         rs = rs,

--- a/R/jamovipdiffpaired.h.R
+++ b/R/jamovipdiffpaired.h.R
@@ -72,10 +72,20 @@ jamovipdiffpairedOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R
                     "from_summary"))
             private$..reference_measure <- jmvcore::OptionVariable$new(
                 "reference_measure",
-                reference_measure)
+                reference_measure,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..comparison_measure <- jmvcore::OptionVariable$new(
                 "comparison_measure",
-                comparison_measure)
+                comparison_measure,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..cases_consistent <- jmvcore::OptionString$new(
                 "cases_consistent",
                 cases_consistent,
@@ -1177,6 +1187,8 @@ jamovipdiffpaired <- function(
             `if`( ! missing(reference_measure), reference_measure, NULL),
             `if`( ! missing(comparison_measure), comparison_measure, NULL))
 
+    for (v in reference_measure) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
+    for (v in comparison_measure) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamovipdiffpairedOptions$new(
         switch = switch,

--- a/R/jamovipdifftwo.h.R
+++ b/R/jamovipdifftwo.h.R
@@ -80,11 +80,17 @@ jamovipdifftwoOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..outcome_variable <- jmvcore::OptionVariables$new(
                 "outcome_variable",
                 outcome_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..grouping_variable <- jmvcore::OptionVariable$new(
                 "grouping_variable",
                 grouping_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..comparison_cases <- jmvcore::OptionString$new(

--- a/R/jamoviproportion.h.R
+++ b/R/jamoviproportion.h.R
@@ -56,7 +56,12 @@ jamoviproportionOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6
                     "from_summary"))
             private$..outcome_variable <- jmvcore::OptionVariables$new(
                 "outcome_variable",
-                outcome_variable)
+                outcome_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
+                permitted=list(
+                    "factor"))
             private$..cases <- jmvcore::OptionString$new(
                 "cases",
                 cases,
@@ -753,6 +758,7 @@ jamoviproportion <- function(
             parent.frame(),
             `if`( ! missing(outcome_variable), outcome_variable, NULL))
 
+    for (v in outcome_variable) if (v %in% names(data)) data[[v]] <- as.factor(data[[v]])
 
     options <- jamoviproportionOptions$new(
         switch = switch,

--- a/R/jamovirdifftwo.h.R
+++ b/R/jamovirdifftwo.h.R
@@ -112,16 +112,23 @@ jamovirdifftwoOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             private$..x <- jmvcore::OptionVariable$new(
                 "x",
                 x,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..y <- jmvcore::OptionVariable$new(
                 "y",
                 y,
+                suggested=list(
+                    "continuous"),
                 permitted=list(
                     "numeric"))
             private$..grouping_variable <- jmvcore::OptionVariable$new(
                 "grouping_variable",
                 grouping_variable,
+                suggested=list(
+                    "nominal",
+                    "ordinal"),
                 permitted=list(
                     "factor"))
             private$..comparison_r <- jmvcore::OptionString$new(

--- a/jamovi/jamovicorrelation.a.yaml
+++ b/jamovi/jamovicorrelation.a.yaml
@@ -24,12 +24,18 @@ options:
     - name: x
       title: <i>X</i> Variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: y
       title: <i>Y</i> variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: r
       type: String

--- a/jamovi/jamovicorrelation.u.yaml
+++ b/jamovi/jamovicorrelation.u.yaml
@@ -15,6 +15,10 @@ children:
           - type: VariableSupplier
             persistentItems: false
             stretchFactor: 1
+            suggested:
+              - continuous
+            permitted:
+              - numeric
             children:
               - type: TargetLayoutBox
                 label: <i>X</i> variable

--- a/jamovi/jamovidescribe.a.yaml
+++ b/jamovi/jamovidescribe.a.yaml
@@ -12,7 +12,10 @@ options:
     - name: outcome_variable
       title: Outcome variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: show_details
       title: Extra details

--- a/jamovi/jamovidescribe.u.yaml
+++ b/jamovi/jamovidescribe.u.yaml
@@ -7,6 +7,10 @@ children:
   - type: VariableSupplier
     persistentItems: false
     stretchFactor: 1
+    suggested:
+      - continuous
+    permitted:
+      - numeric
     children:
       - type: TargetLayoutBox
         label: Outcome variable

--- a/jamovi/jamovimagnitude.a.yaml
+++ b/jamovi/jamovimagnitude.a.yaml
@@ -23,7 +23,10 @@ options:
     - name: outcome_variable
       title: Outcome variable(s)
       type: Variables
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: mean
       title: Mean (<i>M</i>)

--- a/jamovi/jamovimagnitude.u.yaml
+++ b/jamovi/jamovimagnitude.u.yaml
@@ -15,6 +15,10 @@ children:
           - type: VariableSupplier
             persistentItems: false
             stretchFactor: 1
+            suggested:
+              - continuous
+            permitted:
+              - numeric
             children:
               - type: TargetLayoutBox
                 label: Outcome variable

--- a/jamovi/jamovimdiff2x2.a.yaml
+++ b/jamovi/jamovimdiff2x2.a.yaml
@@ -33,27 +33,44 @@ options:
     - name: outcome_variable
       title: Outcome variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: grouping_variable_A
       title: Grouping variable A
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: grouping_variable_B
       title: Grouping variable B
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: outcome_variable_level1
       title: First repeated measure
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: outcome_variable_level2
       title: Second repeated measure
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: outcome_variable_name_bs
       title: 'Outcome variable name'
@@ -63,7 +80,11 @@ options:
     - name: grouping_variable
       title: Grouping variable
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: repeated_measures_name
       title: 'Repeated measure name'

--- a/jamovi/jamovimdiffindcontrast.a.yaml
+++ b/jamovi/jamovimdiffindcontrast.a.yaml
@@ -23,32 +23,52 @@ options:
     - name: outcome_variable
       title: Outcome variable(s)
       type: Variables
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: grouping_variable
       title: Grouping variable
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: means
       title: Group means
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: sds
       title: Group standard deviations
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: ns
       title: Group sample sizes
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: grouping_variable_levels
       title: Grouping variable levels
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: outcome_variable_name
       title: Outcome variable name

--- a/jamovi/jamovimdiffpaired.a.yaml
+++ b/jamovi/jamovimdiffpaired.a.yaml
@@ -23,12 +23,18 @@ options:
     - name: reference_measure
       title: Reference variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: comparison_measure
       title: Comparison variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: comparison_mean
       type: String

--- a/jamovi/jamovimdiffpaired.u.yaml
+++ b/jamovi/jamovimdiffpaired.u.yaml
@@ -15,6 +15,10 @@ children:
           - type: VariableSupplier
             persistentItems: false
             stretchFactor: 1
+            suggested:
+              - continuous
+            permitted:
+              - numeric
             children:
               - type: TargetLayoutBox
                 label: Reference variable

--- a/jamovi/jamovimdifftwo.a.yaml
+++ b/jamovi/jamovimdifftwo.a.yaml
@@ -24,12 +24,19 @@ options:
     - name: outcome_variable
       title: Outcome variable(s)
       type: Variables
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: grouping_variable
       title: Grouping variable
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: reference_level_name
       type: String

--- a/jamovi/jamovimdifftwo.u.yaml
+++ b/jamovi/jamovimdifftwo.u.yaml
@@ -15,6 +15,10 @@ children:
             - type: VariableSupplier
               persistentItems: false
               stretchFactor: 1
+              suggested:
+                - continuous
+                - nominal
+                - ordinal
               children:
                 - type: TargetLayoutBox
                   label: Outcome variable(s)

--- a/jamovi/jamovimetamdiff.a.yaml
+++ b/jamovi/jamovimetamdiff.a.yaml
@@ -23,73 +23,126 @@ options:
     - name: comparison_means
       title: Comparison means (<i>M</i><sub>comparison</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: comparison_sds
       title: Comparison standard deviations (<i>s</i><sub>comparison</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: comparison_ns
       title: Comparison sample sizes (<i>N</i><sub>comparison</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: reference_means
       title: Reference means (<i>M</i><sub>reference</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: reference_sds
       title: Reference standard deviations (<i>s</i><sub>reference</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: reference_ns
       title: Reference sample sizes (<i>N</i><sub>reference</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: r
       title: Correlation between measures (optional)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: labels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: moderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: d
       title: Standardized mean difference, bias corrected
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: dcomparison_ns
       title: Comparison sample sizes (<i>N</i><sub>comparison</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: dreference_ns
       title: Reference sample sizes (<i>N</i><sub>reference</sub>)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: dr
       title: Correlation between measures (optional)
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: dlabels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: dmoderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: conf_level
       type: Number

--- a/jamovi/jamovimetamean.a.yaml
+++ b/jamovi/jamovimetamean.a.yaml
@@ -23,43 +23,78 @@ options:
     - name: means
       title: Means
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: sds
       title: Standard deviations
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: ns
       title: Sample sizes
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: labels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: moderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: ds
       title: Cohen's d unbiased
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: dns
       title: Sample sizes
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: dlabels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: dmoderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: conf_level
       type: Number

--- a/jamovi/jamovimetapdiff.a.yaml
+++ b/jamovi/jamovimetapdiff.a.yaml
@@ -13,30 +13,52 @@ options:
     - name: reference_cases
       title: Case counts in reference group
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: reference_ns
       title: Sample sizes in reference group
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: comparison_cases
       title: Case counts in comparison group
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: comparison_ns
       title: Sample sizes in comparison group
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: labels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: moderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: effect_label
       title: Effect label

--- a/jamovi/jamovimetaproportion.a.yaml
+++ b/jamovi/jamovimetaproportion.a.yaml
@@ -13,20 +13,36 @@ options:
     - name: cases
       title: Case counts
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: ns
       title: Sample sizes
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: labels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: moderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: effect_label
       title: Effect label

--- a/jamovi/jamovimetar.a.yaml
+++ b/jamovi/jamovimetar.a.yaml
@@ -13,20 +13,36 @@ options:
     - name: rs
       title: r values
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: ns
       title: Sample sizes
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: labels
       title: Study labels (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: moderator
       title: Moderator (optional)
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: effect_label
       title: Effect label

--- a/jamovi/jamovipdiffpaired.a.yaml
+++ b/jamovi/jamovipdiffpaired.a.yaml
@@ -23,10 +23,20 @@ options:
     - name: reference_measure
       title: Reference measure
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: comparison_measure
       title: Comparison measure
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: cases_consistent
       type: String

--- a/jamovi/jamovipdiffpaired.u.yaml
+++ b/jamovi/jamovipdiffpaired.u.yaml
@@ -15,6 +15,11 @@ children:
           - type: VariableSupplier
             persistentItems: false
             stretchFactor: 1
+            suggested:
+              - nominal
+              - ordinal
+            permitted:
+              - factor
             children:
               - type: TargetLayoutBox
                 label: Reference measure

--- a/jamovi/jamovipdifftwo.a.yaml
+++ b/jamovi/jamovipdifftwo.a.yaml
@@ -22,13 +22,21 @@ options:
 
     - name: outcome_variable
       title: Outcome variable(s)
-      permitted: [factor]
       type: Variables
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: grouping_variable
       title: Grouping variable
-      permitted: [factor]
       type: Variable
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: comparison_cases
       type: String

--- a/jamovi/jamovipdifftwo.u.yaml
+++ b/jamovi/jamovipdifftwo.u.yaml
@@ -15,6 +15,11 @@ children:
           - type: VariableSupplier
             persistentItems: false
             stretchFactor: 1
+            suggested:
+              - nominal
+              - ordinal
+            permitted:
+              - factor
             children:
               - type: TargetLayoutBox
                 label: Outcome variable(s)

--- a/jamovi/jamoviproportion.a.yaml
+++ b/jamovi/jamoviproportion.a.yaml
@@ -23,6 +23,11 @@ options:
     - name: outcome_variable
       title: Outcome variable
       type: Variables
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: cases
       title: ''

--- a/jamovi/jamoviproportion.u.yaml
+++ b/jamovi/jamoviproportion.u.yaml
@@ -15,6 +15,11 @@ children:
           - type: VariableSupplier
             persistentItems: false
             stretchFactor: 1
+            suggested:
+              - nominal
+              - ordinal
+            permitted:
+              - factor
             children:
               - type: TargetLayoutBox
                 label: Outcome variable

--- a/jamovi/jamovirdifftwo.a.yaml
+++ b/jamovi/jamovirdifftwo.a.yaml
@@ -23,17 +23,27 @@ options:
     - name: x
       title: <i>X</i> Variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: y
       title: <i>Y</i> variable
       type: Variable
-      permitted: [numeric]
+      suggested:
+        - continuous
+      permitted:
+        - numeric
 
     - name: grouping_variable
       title: Grouping variable
       type: Variable
-      permitted: [factor]
+      suggested:
+        - nominal
+        - ordinal
+      permitted:
+        - factor
 
     - name: comparison_r
       type: String


### PR DESCRIPTION
Updated all .a.yaml (and some .u.yaml) to add suggested types to all variable controls (in .a.yaml) and, where only one type is being selected, to variable suppliers (.u.yaml).  This gives move guidance to the used about variable selection and prevents invalid typing with a flashing icon.  In some analyses (jamoviproportion) required variable types weren't set, so these were set along with the new suggested properties.