### PR TITLE
documentation - example code typo fixes

### DIFF
--- a/R/CI_smd_ind_contrast.R
+++ b/R/CI_smd_ind_contrast.R
@@ -192,7 +192,7 @@
 #'   means = c(33.5, 37.9, 38.0, 44.1),
 #'   sds = c(3.84, 3.84, 3.65, 4.98),
 #'   ns = c(10,10,10,10),
-#'   contrast = contrast = c(.5, .5, -.5, -.5),
+#'   contrast = c(.5, .5, -.5, -.5),
 #'   conf_level = 0.95,
 #'   assume_equal_variance = FALSE,
 #'   correct_bias = TRUE

--- a/R/estimate_mdiff_paired.R
+++ b/R/estimate_mdiff_paired.R
@@ -148,7 +148,7 @@
 #' )
 #' estimate
 #'
-#' #' \dontrun{
+#' \dontrun{
 #' # To visualize the estimated median difference (raw data only)
 #' plot_mdiff(estimate, effect_size = "median")
 #' }
@@ -176,7 +176,7 @@
 #'
 #' \dontrun{
 #' # To visualize the estimated mean difference
-#' plot_mdiff(estimate, effect_size = "mean")
+#' # plot_mdiff(estimate, effect_size = "mean")
 #' }
 #'
 #'

--- a/man/CI_smd_ind_contrast.Rd
+++ b/man/CI_smd_ind_contrast.Rd
@@ -194,7 +194,7 @@ CI_smd_ind_contrast(
   means = c(33.5, 37.9, 38.0, 44.1),
   sds = c(3.84, 3.84, 3.65, 4.98),
   ns = c(10,10,10,10),
-  contrast = contrast = c(.5, .5, -.5, -.5),
+  contrast = c(.5, .5, -.5, -.5),
   conf_level = 0.95,
   assume_equal_variance = FALSE,
   correct_bias = TRUE

--- a/man/estimate_mdiff_paired.Rd
+++ b/man/estimate_mdiff_paired.Rd
@@ -195,7 +195,7 @@ estimate <- esci::estimate_mdiff_paired(
 )
 estimate
 
-#' \dontrun{
+\dontrun{
 # To visualize the estimated median difference (raw data only)
 plot_mdiff(estimate, effect_size = "median")
 }
@@ -222,7 +222,7 @@ estimate
 
 \dontrun{
 # To visualize the estimated mean difference
-plot_mdiff(estimate, effect_size = "mean")
+# plot_mdiff(estimate, effect_size = "mean")
 }
 
 


### PR DESCRIPTION
Fixed typos in examples in CM_smd_ind_contrasts and estmate_mdiff_paired