### PR TITLE
Replace ggh4x dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     Rdpack,
     stringr,
     mathjaxr,
-    legendry
+    legendry (>= 0.2)
 RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 RdMacros: Rdpack, mathjaxr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,13 +22,13 @@ Imports:
     metafor,
     ggplot2,
     ggdist,
-    ggh4x,
     ggtext,
     ggbeeswarm,
     glue,
     Rdpack,
     stringr,
-    mathjaxr
+    mathjaxr,
+    legendry
 RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 RdMacros: Rdpack, mathjaxr

--- a/R/jamovimdiff2x2.b.R
+++ b/R/jamovimdiff2x2.b.R
@@ -321,8 +321,11 @@ jamovimdiff2x2Class <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Clas
 
 
         myplot$scales$scales[[2]]$labels <- mylabs
-        myplot <- myplot + ggplot2::guides(x = ggh4x::guide_axis_nested(delim = " - "))
-
+        myplot <- myplot + guides(x = legendry::compose_stack(
+          "line", "ticks",
+          legendry::primitive_bracket(key = legendry::key_range_auto(sep = " - ")),
+          theme = ggplot2::theme(legendry.guide.spacing = ggplot2::unit(0, "cm"))
+        ))
 
         print(myplot)
         TRUE

--- a/R/jamovimdiff2x2.b.R
+++ b/R/jamovimdiff2x2.b.R
@@ -321,11 +321,7 @@ jamovimdiff2x2Class <- if (requireNamespace('jmvcore', quietly=TRUE)) R6::R6Clas
 
 
         myplot$scales$scales[[2]]$labels <- mylabs
-        myplot <- myplot + guides(x = legendry::compose_stack(
-          "line", "ticks",
-          legendry::primitive_bracket(key = legendry::key_range_auto(sep = " - ")),
-          theme = ggplot2::theme(legendry.guide.spacing = ggplot2::unit(0, "cm"))
-        ))
+        myplot <- myplot + guides(x = legendry::guide_axis_nested(key = " - "))
 
         print(myplot)
         TRUE

--- a/R/plot_meta.R
+++ b/R/plot_meta.R
@@ -588,9 +588,11 @@ esci_plot_difference_axis_x <- function(
 
   # Just plot a truncated axis
   myplot <- myplot + ggplot2::guides(
-    x.sec = ggh4x::guide_axis_truncated(
-      trunc_lower = new_lower + reference_value,
-      trunc_upper = new_upper + reference_value
+    x.sec = legendry::guide_axis_base(
+      cap = as.vector(rbind(
+        new_lower + reference_value,
+        new_upper + reference_value
+      ))
     )
   )
 


### PR DESCRIPTION
Hi there,

I'm the author of ggh4x. I plan to deprecate most guide functionality in ggh4x, which would negatively affect esci.
This PR is to help prevent esci from getting in trouble by changes in ggh4x.
The main change is  to replace the guides from ggh4x by guides from the legendry package, a package I wrote specifically to replace the guides in ggh4x.

Best wishes,
Teun